### PR TITLE
Rspec does not work

### DIFF
--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,8 +1,5 @@
 $LOAD_PATH << File.expand_path('../../lib', __FILE__)
 
-require 'codeclimate-test-reporter'
-CodeClimate::TestReporter.start
-
 require 'rails/all'
 require 'js_rails_routes'
 


### PR DESCRIPTION
It seems that `CodeClimate::TestReporter.start` is deprecated.

Ref. https://github.com/codeclimate/ruby-test-reporter/blob/v1.0.8/lib/code_climate/test_reporter.rb