### PR TITLE
About how to use matching routes

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,8 +28,12 @@ Suppose the app has following routes:
 #              PATCH  /articles/:id(.:format)      articles#update
 #              PUT    /articles/:id(.:format)      articles#update
 #              DELETE /articles/:id(.:format)      articles#destroy
-Rails.application.routes.draw do
+#        about GET    /about(.:format)             website#about
+#      summary GET    /summary/:date(.:format)     website#summary
+Rails.applicatwion.routes.draw do
   resources :articles
+  get '/about', :to => 'website#about'
+  get '/summary/:date', :to => 'website#summary', as: :summary
 end
 ```
 
@@ -37,10 +41,12 @@ then `rake js:routes` generates "app/assets/javascripts/rails-routes.js" as:
 
 ```js
 // Don't edit manually. `rake js:routes` generates this file.
+export function about_path(params) { return '/about'; }
 export function article_path(params) { return '/articles/' + params.id + ''; }
 export function articles_path(params) { return '/articles'; }
 export function edit_article_path(params) { return '/articles/' + params.id + '/edit'; }
 export function new_article_path(params) { return '/articles/new'; }
+export function summary_path(params) { return '/summary/' + params.date + ''; }
 ```
 
 ## VS.

--- a/spec/js_rails_routes/generator_spec.rb
+++ b/spec/js_rails_routes/generator_spec.rb
@@ -20,8 +20,9 @@ RSpec.describe JSRailsRoutes::Generator do
           "rake #{task}",
           "'/apps/' + params.id",
           "'/apps/foo'",
-          "'/apps/bar/' + params.date",
-        ))
+          "'/apps/bar/' + params.date"
+        )
+      )
       subject
     end
 

--- a/spec/js_rails_routes/generator_spec.rb
+++ b/spec/js_rails_routes/generator_spec.rb
@@ -15,7 +15,13 @@ RSpec.describe JSRailsRoutes::Generator do
     end
 
     it 'writes a JS file' do
-      expect(generator).to receive(:write).with(a_string_including("rake #{task}"))
+      expect(generator).to receive(:write).with(
+        a_string_including(
+          "rake #{task}",
+          "'/apps/' + params.id",
+          "'/apps/foo'",
+          "'/apps/bar/' + params.date",
+        ))
       subject
     end
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -12,6 +12,8 @@ class TestApp < Rails::Application
   routes.draw do
     resources :blogs
     resources :users
+    get '/apps/foo', to: 'apps#foo'
+    get '/apps/bar/:date', to: 'apps#bar', as: :apps_bar
   end
 end
 


### PR DESCRIPTION
The following code, does not generate routes.

```rb
# config/routes
get '/hoge/:id', to: 'hoge#show'
```

Correctly,

```rb
get '/hoge/:id', to: 'hoge#show', as: :hoge  #=> `hoge_path` is generated.
```

I was puzzled by this behavior :confounded: , so I added it to the README :memo: 
